### PR TITLE
feat: improve pet accessibility

### DIFF
--- a/onimal-game/src/components/Pet.svelte
+++ b/onimal-game/src/components/Pet.svelte
@@ -28,7 +28,15 @@
   }
 </script>
 
-<div class="pet-container {pet.stage}" role="button" tabindex="0" on:click={selectPet} on:keydown={(e) => e.key === 'Enter' && selectPet()}>
+<div
+  class="pet-container {pet.stage}"
+  role="button"
+  tabindex="0"
+  aria-label={`Seleccionar ${pet.name}`}
+  aria-pressed={$gameState.selectedPetId === pet.id}
+  on:click={selectPet}
+  on:keydown={(e) => ['Enter', ' '].includes(e.key) && selectPet()}
+>
   <div class="pet-header">
     <h3>{pet.name}</h3>
     <span class="pet-level">Nivel {pet.level}</span>

--- a/onimal-game/tests/components/Pet.test.ts
+++ b/onimal-game/tests/components/Pet.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { get } from 'svelte/store'
+import { gameState } from '../../src/stores/gameState.js'
 
 // Test simplificado para componente Pet sin mounting DOM
 // Estos tests verifican la lógica en lugar del rendering
@@ -99,5 +101,27 @@ describe('Pet Component Logic', () => {
   it('should maintain pet ID uniqueness format', () => {
     expect(mockPet.id).toMatch(/^[a-zA-Z0-9-_]+$/)
     expect(mockPet.id.length).toBeGreaterThan(0)
+  })
+})
+
+describe('Pet Component Accessibility', () => {
+  beforeEach(() => {
+    gameState.reset()
+  })
+
+  it('should select pet when Space key is pressed', () => {
+    const mockPetId = 'access-pet-1'
+    const handler = (e: KeyboardEvent) => {
+      if (['Enter', ' '].includes(e.key)) {
+        gameState.selectPet(mockPetId)
+      }
+    }
+
+    const element = document.createElement('div')
+    element.addEventListener('keydown', handler)
+    const event = new KeyboardEvent('keydown', { key: ' ' })
+    element.dispatchEvent(event)
+
+    expect(get(gameState).selectedPetId).toBe(mockPetId)
   })
 })


### PR DESCRIPTION
## Summary
- handle Enter and Space keys to select pets and announce state
- add unit test covering space key selection

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689620866d9483259f3e7ed5366b5154