### PR TITLE
Centralize pet creation with validation checks

### DIFF
--- a/onimal-game/src/App.svelte
+++ b/onimal-game/src/App.svelte
@@ -1,6 +1,7 @@
 <script>
   import Pet from './components/Pet.svelte';
   import { gameState } from './stores/gameState.js';
+  import { tryAddPet } from './lib/createPet.js';
   import { onMount } from 'svelte';
   
   onMount(() => {
@@ -8,32 +9,8 @@
   });
 
   function addTestPet() {
-    const newPet = {
-      id: `pet-${Date.now()}`,
-      name: `Mascota ${$gameState.pets.length + 1}`,
-      species: ['canine', 'feline', 'avian', 'reptile', 'amphibian'][Math.floor(Math.random() * 5)],
-      stage: 'cria',
-      level: 1,
-      experience: 0,
-      needs: {
-        hunger: 80,
-        happiness: 90,
-        energy: 100,
-        health: 100
-      },
-      currentAnimation: 'idle',
-      birthTime: Date.now(),
-      lastCared: Date.now(),
-      stats: {
-        strength: 10,
-        intelligence: 10,
-        agility: 10,
-        charisma: 10
-      }
-    };
-    
-    gameState.addPet(newPet);
-    gameState.save();
+    const name = `Mascota ${$gameState.pets.length + 1}`;
+    tryAddPet(name);
   }
 </script>
 

--- a/onimal-game/src/lib/createPet.js
+++ b/onimal-game/src/lib/createPet.js
@@ -1,0 +1,48 @@
+import { gameState } from '../stores/gameState.js';
+
+export const PET_ADOPTION_COST = 50;
+
+export function tryAddPet(name) {
+  let createdPet = null;
+  gameState.update(state => {
+    if (state.coins < PET_ADOPTION_COST) {
+      return state;
+    }
+    if (state.pets.some(p => p.name === name)) {
+      return state;
+    }
+    const newPet = {
+      id: `pet-${Date.now()}`,
+      name,
+      species: ['canine', 'feline', 'avian', 'reptile', 'amphibian'][Math.floor(Math.random() * 5)],
+      stage: 'cria',
+      level: 1,
+      experience: 0,
+      needs: {
+        hunger: 80,
+        happiness: 90,
+        energy: 100,
+        health: 100
+      },
+      currentAnimation: 'idle',
+      birthTime: Date.now(),
+      lastCared: Date.now(),
+      stats: {
+        strength: 10,
+        intelligence: 10,
+        agility: 10,
+        charisma: 10
+      }
+    };
+    createdPet = newPet;
+    return {
+      ...state,
+      coins: state.coins - PET_ADOPTION_COST,
+      pets: [...state.pets, newPet]
+    };
+  });
+  if (createdPet) {
+    gameState.save();
+  }
+  return createdPet;
+}

--- a/onimal-game/tests/unit/petCreation.test.ts
+++ b/onimal-game/tests/unit/petCreation.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import { gameState } from '../../src/stores/gameState.js';
+import { tryAddPet } from '../../src/lib/createPet.js';
+
+describe('pet creation helper', () => {
+  beforeEach(() => {
+    gameState.reset();
+  });
+
+  it('does not create pets with duplicate names', () => {
+    const name = 'Buddy';
+    const first = tryAddPet(name);
+    const second = tryAddPet(name);
+
+    const state = get(gameState);
+    expect(first).not.toBeNull();
+    expect(second).toBeNull();
+    expect(state.pets).toHaveLength(1);
+    expect(state.pets[0].name).toBe(name);
+  });
+
+  it('does not create pets when coins are insufficient', () => {
+    gameState.spendCoins(100); // leave 0 coins
+    const result = tryAddPet('PoorPet');
+    const state = get(gameState);
+
+    expect(result).toBeNull();
+    expect(state.pets).toHaveLength(0);
+    expect(state.coins).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- centralize pet adoption in helper that checks coin balance and existing names
- update App to use helper
- add tests for duplicate names and insufficient funds

## Testing
- `npm run test:run`

------
https://chatgpt.com/codex/tasks/task_e_689620893ab88325b33c1c043bcab212